### PR TITLE
fix memory leak

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -65,8 +65,8 @@ int drop_table(Table *table) {
   free(table->rows);
 
   /* free table */
-  free(table);
   hash_del(tables, table->name);
+  free(table);
 
   return 0;
 }


### PR DESCRIPTION
`hash_del()` takes` table->name` as it's argument, but `free()` called above makes it invalid value, so I think it's better to call `free(table`) after `hash_del(tables, table->name)`.